### PR TITLE
Docs fix: big-endianness is assumed for multi-byte values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Here is how you read first a single bit, then three bits and finally four bits f
 
 You can naturally read bits from longer buffer of data than just a single byte.
 
-As you read bits, the internal cursor of BitReader moves on along the stream of bits. Little endian format is assumed when reading the multi-byte values. BitReader supports reading maximum of 64 bits at a time (with read_u64).
+As you read bits, the internal cursor of BitReader moves on along the stream of bits. Big endian format is assumed when reading the multi-byte values. BitReader supports reading maximum of 64 bits at a time (with read_u64).
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! ```
 //! You can naturally read bits from longer buffer of data than just a single byte.
 //!
-//! As you read bits, the internal cursor of BitReader moves on along the stream of bits. Little
+//! As you read bits, the internal cursor of BitReader moves on along the stream of bits. Big
 //! endian format is assumed when reading the multi-byte values. BitReader supports reading maximum
 //! of 64 bits at a time (with read_u64). Reading signed values directly is not supported at the
 //! moment.


### PR DESCRIPTION
println!("{:04x}", reader.read_u16(16).unwrap());
on a &[0x01, 0x02] prints 0x0102 (as it should).