### PR TITLE
Add .peek_*() functions in addition to .read_*()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,18 @@ impl<'a> BitReader<'a> {
         self.position % (alignment_bytes as u64 * 8) == 0
     }
 
+    /// Helper to move the "bit cursor" to exactly the beginning of a byte, or to a specific
+    /// multi-byte alignment position.
+    ///
+    /// That is, `reader.align(n)` moves the cursor to the next position that
+    /// is a multiple of n * 8 bits, if it's not correctly aligned already.
+    pub fn align(&mut self, alignment_bytes: u32) -> Result<()> {
+        let alignment_bits = alignment_bytes as u64 * 8;
+        let cur_alignment = self.position % alignment_bits;
+        let bits_to_skip = (alignment_bits - cur_alignment) % alignment_bits;
+        self.skip(bits_to_skip)
+    }
+
     fn read_signed_value(&mut self, bit_count: u8, maximum_count: u8) -> Result<i64> {
         let unsigned = self.read_value(bit_count, maximum_count)?;
         // Fill the bits above the requested bits with all ones or all zeros,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,11 @@ impl<'a> BitReader<'a> {
         Ok((value & 0xff) as u8)
     }
 
+    /// Read at most 8 bits into a u8, but without moving the cursor forward.
+    pub fn peek_u8(&self, bit_count: u8) -> Result<u8> {
+        self.relative_reader().read_u8(bit_count)
+    }
+
     /// Fills the entire `output_bytes` slice. If there aren't enough bits remaining
     /// after the internal cursor's current position, the cursor won't be moved forward
     /// and the contents of `output_bytes` won't be modified.
@@ -143,16 +148,31 @@ impl<'a> BitReader<'a> {
         Ok((value & 0xffff) as u16)
     }
 
+    /// Read at most 16 bits into a u16, but without moving the cursor forward.
+    pub fn peek_u16(&self, bit_count: u8) -> Result<u16> {
+        self.relative_reader().read_u16(bit_count)
+    }
+
     /// Read at most 32 bits into a u32.
     pub fn read_u32(&mut self, bit_count: u8) -> Result<u32> {
         let value = self.read_value(bit_count, 32)?;
         Ok((value & 0xffffffff) as u32)
     }
 
+    /// Read at most 32 bits into a u32, but without moving the cursor forward.
+    pub fn peek_u32(&self, bit_count: u8) -> Result<u32> {
+        self.relative_reader().read_u32(bit_count)
+    }
+
     /// Read at most 64 bits into a u64.
     pub fn read_u64(&mut self, bit_count: u8) -> Result<u64> {
         let value = self.read_value(bit_count, 64)?;
         Ok(value)
+    }
+
+    /// Read at most 64 bits into a u64, but without moving the cursor forward.
+    pub fn peek_u64(&self, bit_count: u8) -> Result<u64> {
+        self.relative_reader().read_u64(bit_count)
     }
 
     /// Read at most 8 bits into a i8.
@@ -190,6 +210,12 @@ impl<'a> BitReader<'a> {
             0 => Ok(false),
             _ => Ok(true),
         }
+    }
+
+    /// Read a single bit as a boolean value, but without moving the cursor forward.
+    /// Interprets 1 as true and 0 as false.
+    pub fn peek_bool(&self) -> Result<bool> {
+        self.relative_reader().read_bool()
     }
 
     /// Skip arbitrary number of bits. However, you can skip at most to the end of the byte slice.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,6 +18,7 @@ fn read_buffer() {
     let mut reader = BitReader::new(bytes);
 
     assert_eq!(reader.read_u8(1).unwrap(), 0b1);
+    assert_eq!(reader.peek_u8(3).unwrap(), 0b011);
     assert_eq!(reader.read_u8(1).unwrap(), 0b0);
     assert_eq!(reader.read_u8(2).unwrap(), 0b11);
 
@@ -36,7 +37,13 @@ fn read_buffer() {
 
     assert_eq!(reader.align(1), Ok(())); // shouldn't do anything if already aligned
 
+    assert_eq!(reader.peek_u64(16).unwrap(), 0b110_1010_1010_1100);
     assert_eq!(reader.read_u8(3).unwrap(), 0b11);
+    assert_eq!(reader.peek_u16(13).unwrap(), 0b1010_1010_1100);
+    assert_eq!(reader.peek_u32(13).unwrap(), 0b1010_1010_1100);
+    assert_eq!(reader.peek_u64(13).unwrap(), 0b1010_1010_1100);
+    assert_eq!(reader.peek_u16(10).unwrap(), 0b01_0101_0101);
+    assert_eq!(reader.peek_u8(8).unwrap(), 0b0101_0101);
     assert_eq!(reader.read_u16(10).unwrap(), 0b01_0101_0101);
     assert_eq!(reader.read_u8(3).unwrap(), 0b100);
 
@@ -47,8 +54,11 @@ fn read_buffer() {
 
     assert_eq!(reader.read_u32(32).unwrap(), 0b1001_1001_1001_1001_1001_1001_1001_1001);
 
+    assert_eq!(reader.peek_bool().unwrap(), true);
     assert_eq!(reader.read_u8(4).unwrap(), 0b1110);
+    assert_eq!(reader.peek_bool().unwrap(), false);
     assert_eq!(reader.read_u8(3).unwrap(), 0b011);
+    assert_eq!(reader.peek_bool().unwrap(), true);
     assert_eq!(reader.read_bool().unwrap(), true);
 
     // Could also be 8 at this point!


### PR DESCRIPTION
Allows to check the next few bits without moving the cursor forward.

Again not mission critical, but nice to have.

--- 

On top of #14 