### PR TITLE
Check for std when using std features.

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -221,6 +221,7 @@ fn signed_values() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn boolean_values() {
     let bytes: Vec<u8> = (0..16).collect();


### PR DESCRIPTION
`cargo test --no-default-features` fails without this.