### PR TITLE
Fix left-shift-with-overflow panic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,6 +322,10 @@ impl<'a> BitReader<'a> {
         // depending on the sign bit.
         let sign_bit = unsigned >> (bit_count - 1) & 1;
         let high_bits = if sign_bit == 1 { -1 } else { 0 };
+        if bit_count == 64 {
+            // Avoid left-shift-with-overflow exception
+            return Ok(unsigned as i64);
+        }
         Ok(high_bits << bit_count | unsigned as i64)
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -315,3 +315,17 @@ fn relative_reader() {
         requested: 1
     });
 }
+
+#[test]
+fn test_read_u64_max() {
+    let bytes = &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    let mut reader = BitReader::new(bytes);
+    assert_eq!(reader.read_u64(64).unwrap(), u64::MAX);
+}
+
+#[test]
+fn test_read_i64_max() {
+    let bytes = &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    let mut reader = BitReader::new(bytes);
+    assert_eq!(reader.read_i64(64).unwrap(), -1);
+}


### PR DESCRIPTION
- while working with 64bit signed integers, I noticed that reading a 64-bit unsigned integer would cause a panic to be triggered, caused by bitshifting 64 times. This results in rust triggering a "attempt to shift left with overflow" exception.
- This commit adds a test case to trigger this behavior, and comes with a small fix.