### PR TITLE
fix panic for creating relative reader multiple times

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,13 +115,13 @@ impl<'a> BitReader<'a> {
             bytes: self.bytes,
             position: self.position,
             relative_offset: self.position,
-            length: self.length - self.position,
+            length: self.length - self.position(),
         }
     }
 
     /// Returns a copy of current BitReader, with the difference that its position() returns
     /// positions relative to the position of the original BitReader at the construction time, and
-    /// will not allow reading more than len bits. After construction, both readers are otherwise 
+    /// will not allow reading more than len bits. After construction, both readers are otherwise
     // completely independent, except of course for sharing the same source data.
     ///
     /// ```
@@ -153,7 +153,7 @@ impl<'a> BitReader<'a> {
             bytes: self.bytes,
             position: self.position,
             relative_offset: self.position,
-            length: min(self.length - self.position, len),
+            length: min(self.length - self.position(), len),
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -339,3 +339,15 @@ fn relative_reader_remaining() {
     assert_eq!(reader.remaining(), 14);
     assert_eq!(relative_reader.remaining(), 14);
 }
+
+#[test]
+fn make_relate_reader_twice() {
+    let bytes = &[0b0011_0100, 0b0011_0100];
+    let mut reader = BitReader::new(bytes);
+    reader.skip(9).unwrap();
+    let relate_reader_a = reader.relative_reader();
+    let relate_reader_b = relate_reader_a.relative_reader();
+    assert_eq!(relate_reader_a.position(), 0);
+    assert_eq!(relate_reader_b.position(), 0);
+    assert_eq!(relate_reader_a.position, relate_reader_b.position);
+}


### PR DESCRIPTION
According the issue https://github.com/irauta/bitreader/issues/22 , creating relative reader multiple times will panic.

Running the test case in this PR could reproduce this panic (subtract overflow). The root reason is the `position` in `BitReader` is marking the real location in the bit stream, but `length` is relatived with the original reader.