### PR TITLE
Optimize out size checks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub struct BitReader<'a> {
 impl<'a> BitReader<'a> {
     /// Construct a new BitReader from a byte slice. The returned reader lives at most as long as
     /// the slice given to is valid.
+    #[inline]
     pub fn new(bytes: &'a [u8]) -> BitReader<'a> {
         BitReader {
             bytes: bytes,
@@ -110,6 +111,7 @@ impl<'a> BitReader<'a> {
     /// assert_eq!(original.position(), 12);
     /// assert_eq!(relative.position(), 8);
     /// ```
+    #[inline]
     pub fn relative_reader(&self) -> BitReader<'a> {
         BitReader {
             bytes: self.bytes,
@@ -148,6 +150,7 @@ impl<'a> BitReader<'a> {
     ///    requested: 8
     /// });
     /// ```
+    #[inline]
     pub fn relative_reader_atmost(&self, len: u64) -> BitReader<'a> {
         BitReader {
             bytes: self.bytes,
@@ -164,6 +167,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 8 bits into a u8, but without moving the cursor forward.
+    #[inline]
     pub fn peek_u8(&self, bit_count: u8) -> Result<u8> {
         self.relative_reader().read_u8(bit_count)
     }
@@ -194,6 +198,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 16 bits into a u16, but without moving the cursor forward.
+    #[inline]
     pub fn peek_u16(&self, bit_count: u8) -> Result<u16> {
         self.relative_reader().read_u16(bit_count)
     }
@@ -205,6 +210,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 32 bits into a u32, but without moving the cursor forward.
+    #[inline]
     pub fn peek_u32(&self, bit_count: u8) -> Result<u32> {
         self.relative_reader().read_u32(bit_count)
     }
@@ -216,6 +222,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 64 bits into a u64, but without moving the cursor forward.
+    #[inline]
     pub fn peek_u64(&self, bit_count: u8) -> Result<u64> {
         self.relative_reader().read_u64(bit_count)
     }
@@ -259,6 +266,7 @@ impl<'a> BitReader<'a> {
 
     /// Read a single bit as a boolean value, but without moving the cursor forward.
     /// Interprets 1 as true and 0 as false.
+    #[inline]
     pub fn peek_bool(&self) -> Result<bool> {
         self.relative_reader().read_bool()
     }
@@ -278,11 +286,13 @@ impl<'a> BitReader<'a> {
     }
 
     /// Returns the position of the cursor, or how many bits have been read so far.
+    #[inline]
     pub fn position(&self) -> u64 {
         self.position - self.relative_offset
     }
 
     /// Returns the number of bits not yet read from the underlying slice.
+    #[inline]
     pub fn remaining(&self) -> u64 {
         self.length - self.position()
     }
@@ -297,6 +307,7 @@ impl<'a> BitReader<'a> {
     /// This function can be used to validate the data is being read properly, for example by
     /// adding invocations wrapped into `debug_assert!()` to places where it is known the data
     /// should be n-byte aligned.
+    #[inline]
     pub fn is_aligned(&self, alignment_bytes: u32) -> bool {
         self.position % (alignment_bytes as u64 * 8) == 0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 8 bits into a u8.
+    #[inline]
     pub fn read_u8(&mut self, bit_count: u8) -> Result<u8> {
         let value = self.read_value(bit_count, 8)?;
         Ok((value & 0xff) as u8)
@@ -192,6 +193,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 16 bits into a u16.
+    #[inline]
     pub fn read_u16(&mut self, bit_count: u8) -> Result<u16> {
         let value = self.read_value(bit_count, 16)?;
         Ok((value & 0xffff) as u16)
@@ -204,6 +206,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 32 bits into a u32.
+    #[inline]
     pub fn read_u32(&mut self, bit_count: u8) -> Result<u32> {
         let value = self.read_value(bit_count, 32)?;
         Ok((value & 0xffffffff) as u32)
@@ -216,6 +219,7 @@ impl<'a> BitReader<'a> {
     }
 
     /// Read at most 64 bits into a u64.
+    #[inline]
     pub fn read_u64(&mut self, bit_count: u8) -> Result<u64> {
         let value = self.read_value(bit_count, 64)?;
         Ok(value)
@@ -229,6 +233,7 @@ impl<'a> BitReader<'a> {
 
     /// Read at most 8 bits into a i8.
     /// Assumes the bits are stored in two's complement format.
+    #[inline]
     pub fn read_i8(&mut self, bit_count: u8) -> Result<i8> {
         let value = self.read_signed_value(bit_count, 8)?;
         Ok((value & 0xff) as i8)
@@ -236,6 +241,7 @@ impl<'a> BitReader<'a> {
 
     /// Read at most 16 bits into a i16.
     /// Assumes the bits are stored in two's complement format.
+    #[inline]
     pub fn read_i16(&mut self, bit_count: u8) -> Result<i16> {
         let value = self.read_signed_value(bit_count, 16)?;
         Ok((value & 0xffff) as i16)
@@ -243,6 +249,7 @@ impl<'a> BitReader<'a> {
 
     /// Read at most 32 bits into a i32.
     /// Assumes the bits are stored in two's complement format.
+    #[inline]
     pub fn read_i32(&mut self, bit_count: u8) -> Result<i32> {
         let value = self.read_signed_value(bit_count, 32)?;
         Ok((value & 0xffffffff) as i32)
@@ -250,6 +257,7 @@ impl<'a> BitReader<'a> {
 
     /// Read at most 64 bits into a i64.
     /// Assumes the bits are stored in two's complement format.
+    #[inline]
     pub fn read_i64(&mut self, bit_count: u8) -> Result<i64> {
         let value = self.read_signed_value(bit_count, 64)?;
         Ok(value)
@@ -257,6 +265,7 @@ impl<'a> BitReader<'a> {
 
     /// Read a single bit as a boolean value.
     /// Interprets 1 as true and 0 as false.
+    #[inline]
     pub fn read_bool(&mut self) -> Result<bool> {
         match self.read_value(1, 1)? {
             0 => Ok(false),
@@ -324,6 +333,7 @@ impl<'a> BitReader<'a> {
         self.skip(bits_to_skip)
     }
 
+    #[inline]
     fn read_signed_value(&mut self, bit_count: u8, maximum_count: u8) -> Result<i64> {
         if bit_count == 0 {
             return Ok(0);
@@ -340,17 +350,28 @@ impl<'a> BitReader<'a> {
         Ok(high_bits << bit_count | unsigned as i64)
     }
 
+    #[cold]
+    fn too_many_bits_for_type_error(&self, bit_count: u8, maximum_count: u8) -> Result<u64> {
+        Err(BitReaderError::TooManyBitsForType {
+            position: self.position,
+            requested: bit_count,
+            allowed: maximum_count,
+        })
+    }
+
+    #[inline]
+    // Inlining allows the size checks to be eliminated for constant values
     fn read_value(&mut self, bit_count: u8, maximum_count: u8) -> Result<u64> {
         if bit_count == 0 {
             return Ok(0);
         }
         if bit_count > maximum_count {
-            return Err(BitReaderError::TooManyBitsForType {
-                position: self.position,
-                requested: bit_count,
-                allowed: maximum_count,
-            });
+            return self.too_many_bits_for_type_error(bit_count, maximum_count);
         }
+        self.read_bits(bit_count)
+    }
+
+    fn read_bits(&mut self, bit_count: u8) -> Result<u64> {
         let start_position = self.position;
         let end_position = self.position + bit_count as u64;
         if end_position > (self.relative_offset + self.length) {


### PR DESCRIPTION
In my experience the, `read_T()` functions are usually called with a number of bits that's constant or easily visible to the optimizer (like `read_u8(5)` or `read_u8(if extra {6} else {5})`.

This change encourages the optimizer to inline the `bit_count` checks without explicitly inlining rest of the reader code, which makes the bit-count-checking code disappear entirely.

I've used `#[cold]` attribute, which requires Rust 1.48, which I think it's still [very low baseline](https://lib.rs/stats#rustc), but that can be easily removed if you'd like to keep MSRV 1.31.
